### PR TITLE
intake-xarray 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.0" %}
+{% set version = "0.6.1" %}
 
 package:
    name: intake-xarray
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/intake-xarray/intake-xarray-{{ version }}.tar.gz
-  sha256: fa8166e7ef3e665d9b78e48ef74e9cb78e1bf2b2edc9c65278796336b07e8a24
+  sha256: 63dc2a8b937d8f956255d8f8641f08ea654b2d9e88687ec3d1ccc66462fabf9e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  # intake and python-snappy currently aren't available on s390x
-  # xarray is available for py>=3.8
+  # intake, zarr, namcodecs, and python-snappy currently aren't available on s390x
+  # xarray and zarr are available for py>=3.8
   skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
 
 build:
   number: 0
-  # # intake and python-snappy currently aren't available on s390x
-  skip: True  # [py<35 or s390x]
+  # intake and python-snappy currently aren't available on s390x
+  # xarray is available for py>=3.8
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
   summary: xarray plugins for Intake
   description:
     This package enables the set of data-loading methods from Xarray to be used within the Intake data access and cataloging system.
-  doc_url: https://intake-xarray.readthedocs.io/en/latest/
+  doc_url: https://intake-xarray.readthedocs.io/
   dev_url: https://github.com/intake/intake-xarray
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,55 @@
+{% set name = "intake-xarray" %}
 {% set version = "0.6.1" %}
 
 package:
-   name: intake-xarray
-   version: {{ version }}
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/i/intake-xarray/intake-xarray-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 63dc2a8b937d8f956255d8f8641f08ea654b2d9e88687ec3d1ccc66462fabf9e
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  # # intake and python-snappy currently aren't available on s390x
+  skip: True  # [py<35 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
-    - intake >=0.5.2
-    - xarray >=0.12.0
-    - zarr
-    - dask >=2.2
+    - python
+    - dask-core >=2.2
+    - fsspec >=2022
+    - intake >=0.6.6
+    - msgpack-python
     - netcdf4
+    - requests
+    - xarray >=2022
+    - zarr
 
 test:
   imports:
     - intake_xarray
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: https://github.com/ContinuumIO/intake-xarray
+  home: https://github.com/intake/intake-xarray
   license: BSD-2-Clause
-  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  license_family: BSD
+  license_file: LICENSE
   summary: xarray plugins for Intake
+  description:
+    This package enables the set of data-loading methods from Xarray to be used within the Intake data access and cataloging system.
+  doc_url: https://intake-xarray.readthedocs.io/en/latest/
+  dev_url: https://github.com/intake/intake-xarray
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Jira ticket:** [PKG-788](https://anaconda.atlassian.net/browse/PKG-788) (intake-xarray 0.6.1)

**The upstream data:**
License: https://github.com/intake/intake-xarray/blob/0.6.1/LICENSE
Requirements: https://github.com/intake/intake-xarray/blob/0.6.1/setup.py

**_Actions:_**

1. Remove `noarch`
2. Skip `py<35` and `s390x`
3. Add missing `wheel` and `setuptools` to `host`
4. Update `run` dependencies
5. Add `pip check`
6. Update `license_file`
7. Add `license_family`
8. Add a `description`
9. Add `doc_url` & `dev_url`

**_Notes:_**
 * We need to update `xarray` https://github.com/AnacondaRecipes/xarray-feedstock/pull/10 and `zarr` https://github.com/AnacondaRecipes/zarr-feedstock/pull/6

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.6.1
 * Release on PyPi:
    * version: 0.6.1
    * date: 2022-08-26T19:25:59
* [PyPi history](https://pypi.org/project/intake-xarray/#history)
 * Popularity: 
    * 3 months downloads: 6624.0
    * All time:  105356 downloads -  intake-xarray  0.6.1  xarray plugins for Intake  

</details>

**Other checks:**

<details>

1. - [ ] The upstream url error:
    https://github.com/ContinuumIO/intake-xarray/tree/0.6.1
    301
10. - [ ] The upstream url error:
    https://github.com/ContinuumIO/intake-xarray
    301
11. - [ ] Check the pinnings
12. - [ ] Changelog url error:
    https://github.com/ContinuumIO/intake-xarray/tree/0.6.1
    301
13. - [ ] Additional research
    https://github.com/ContinuumIO/intake-xarray/issues
    301
14. - [ ] `dev_url` error:
    https://github.com/ContinuumIO/intake-xarray
    301
15. - [ ] `doc_url` error:
    
    
16. - [ ] Verify that the `build_number` is correct
17. - [ ] Verify if the package needs `setuptools`
    
18. - [ ] Verify if the package needs `wheel`
    
19. - [ ] NO `pip` in test
    
20. - [ ] Verify the test section
21. - [ ] Verify if the package is `architecture specific`
22. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
23.  - [x] license_file: '{{ is present
24. - [x] License: BSD-2-Clause
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |

25. - [ ] License family is NOT present
    
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/intake-xarray-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/intake-xarray-feedstock/tree/0.6.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/intake-xarray)
* [Diff between upstream and feature branch](https://github.com/conda-forge/intake-xarray-feedstock/compare/main...AnacondaRecipes:0.6.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/intake-xarray-feedstock/compare/master...AnacondaRecipes:0.6.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/intake-xarray-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.6.1 git@github.com:AnacondaRecipes/intake-xarray-feedstock.git
```
