### PR TITLE
Rebuild against python 3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-fix-py-311-configparser.patch  # [py>311]
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
intake-xarray 2.0.0

**Destination channel:**  defaults

### Links

- [PKG-12074](https://anaconda.atlassian.net/browse/PKG-12074) 
- [Upstream repository](https://github.com/intake/intake-xarray/tree/2.0.0)

### Explanation of changes:
- Rebuild with python 3.14
- New build number


[PKG-12074]: https://anaconda.atlassian.net/browse/PKG-12074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ